### PR TITLE
Update links in documentation and clarify Bad Packets' involvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ About
 -----
 
 Badcapt is a project inspired by
-[@Bad_Packets](https://twitter.com/bad_packets) work and the
+[Bad Packets'](https://badpackets.net) work and the
 [Remote Identification of Port Scan Toolchains](http://pure.tudelft.nl/ws/files/10611227/10611102.pdf)
 paper by Vincent Ghiette, Norbert Blenn, Christian Doerr.
 
-It will try to detect *bad* packets and export them to the Elastic storage or
+It will try to detect malicious packets and export them to the Elastic storage or
 output to the stdout for your further processing.
 
 Install


### PR DESCRIPTION
We love open source software at Bad Packets and we're happy to see you were inspired by our work!

I'm submitting this pull request in order to prevent confusion between the badcapt project and the commercial use of Bad Packets LLC's Bad Packets trademark. I've modified the readme to use 'malicious packets' rather than 'bad packets'. Additionally, I've changed the link from our [twitter page](https://twitter.com/bad_packets) to [our homepage](https://badpackets.net).

Thanks for taking this request and for crediting us and what we do.